### PR TITLE
fix: /fly command

### DIFF
--- a/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
+++ b/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
@@ -11,11 +11,12 @@ import org.bukkit.entity.Player
 
 fun RootIdoCommands.movementCommands() {
     "fly" {
-        playerExecutes(FloatArgumentType.floatArg(0.0f, 10.0f),) { speed ->
+        playerExecutes(FloatArgumentType.floatArg(0.0f, 10.0f).default{1.0.toFloat()},) { speed ->
             when (player.allowFlight) {
                 true -> {
                     player.allowFlight = false
                     player.fallDistance = 0f
+                    player.flySpeed = speed.div(10)
                     player.error(if (sender == player) "Flight is now disabled!" else "Flight disabled for ${player.name}")
                 }
                 false -> {

--- a/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
+++ b/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
@@ -16,11 +16,11 @@ fun RootIdoCommands.movementCommands() {
                 true -> {
                     player.allowFlight = false
                     player.fallDistance = 0f
-                    player.flySpeed = speed.div(10)
                     player.error(if (sender == player) "Flight is now disabled!" else "Flight disabled for ${player.name}")
                 }
                 false -> {
                     player.allowFlight = true
+                    player.flySpeed = speed.div(10)
                     player.success(if (player == sender) "Flight is now enabled!" else "Flight enabled for ${player.name}")
                 }
             }

--- a/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
+++ b/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
@@ -11,7 +11,7 @@ import org.bukkit.entity.Player
 
 fun RootIdoCommands.movementCommands() {
     "fly" {
-        playerExecutes(FloatArgumentType.floatArg(0.0f, 10.0f).default{(-1).toFloat()},) { speed ->
+        playerExecutes(FloatArgumentType.floatArg(0.0f, 10.0f).default{(-1).toFloat()}) { speed ->
             when (player.allowFlight) {
                 true -> {
                     player.allowFlight = false

--- a/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
+++ b/src/main/kotlin/com/mineinabyss/extracommands/commands/MovementCommands.kt
@@ -11,7 +11,7 @@ import org.bukkit.entity.Player
 
 fun RootIdoCommands.movementCommands() {
     "fly" {
-        playerExecutes(FloatArgumentType.floatArg(0.0f, 10.0f).default{1.0.toFloat()},) { speed ->
+        playerExecutes(FloatArgumentType.floatArg(0.0f, 10.0f).default{(-1).toFloat()},) { speed ->
             when (player.allowFlight) {
                 true -> {
                     player.allowFlight = false
@@ -20,7 +20,8 @@ fun RootIdoCommands.movementCommands() {
                 }
                 false -> {
                     player.allowFlight = true
-                    player.flySpeed = speed.div(10)
+                    if (speed != (-1).toFloat()) // Only apply fly speed change when specified by player
+                        player.flySpeed = speed.div(10)
                     player.success(if (player == sender) "Flight is now enabled!" else "Flight enabled for ${player.name}")
                 }
             }


### PR DESCRIPTION
The /fly command currently requires an additional float argument that is not used for anything. This PR introduces 2 fixes:

1. The /fly command no longer requires the float argument
2. The /fly command, when called with a float argument (e.g., /fly 10), will set the player's fly speed when flying is being enabled.